### PR TITLE
fix: update content in Hero & Agenda

### DIFF
--- a/src/components/pages/home/agenda/agenda.jsx
+++ b/src/components/pages/home/agenda/agenda.jsx
@@ -3,19 +3,21 @@ import React from 'react';
 
 import Container from 'components/shared/container';
 import Heading from 'components/shared/heading';
+import Link from 'components/shared/link';
 
 import shape1 from './images/shape-1.svg';
 import shape2 from './images/shape-2.svg';
 
-const Agenda = ({ title, subtitle, description }) => (
+const Agenda = ({ title, subtitle, link, description }) => (
   <section className="relative text-center text-white bg-black py-28 md:py-20" id="agenda">
-    <img className="absolute top-0 left-0 md:h-full sm:hidden" src={shape1} alt="" aria-hidden />
-    <img className="absolute top-0 right-0 md:h-full sm:hidden" src={shape2} alt="" aria-hidden />
+    <img className="absolute top-0 left-0 h-full sm:hidden" src={shape1} alt="" aria-hidden />
+    <img className="absolute top-0 right-0 h-full sm:hidden" src={shape2} alt="" aria-hidden />
     <Container className="max-w-[592px]">
       <Heading tag="h2">{title}</Heading>
-      <h3 className="mt-12 text-3xl font-extrabold leading-none text-primary-1 md:text-2xl md:mt-6">
-        {subtitle}
-      </h3>
+      <p className="mt-12 text-lg text-white md:text-base md:mt-6">{subtitle}</p>
+      <Link className="block mt-6 text-xl font-bold md:text-lg text-primary-1" to={link.url}>
+        {link.title}
+      </Link>
       <p className="mt-4 text-lg md:text-base">{description}</p>
     </Container>
   </section>
@@ -24,6 +26,10 @@ const Agenda = ({ title, subtitle, description }) => (
 Agenda.propTypes = {
   title: PropTypes.string.isRequired,
   subtitle: PropTypes.string.isRequired,
+  link: PropTypes.shape({
+    url: PropTypes.string.isRequired,
+    title: PropTypes.string.isRequired,
+  }).isRequired,
   description: PropTypes.string.isRequired,
 };
 

--- a/src/components/pages/home/hero/hero.jsx
+++ b/src/components/pages/home/hero/hero.jsx
@@ -59,7 +59,7 @@ const Hero = ({ date, title, description, button1, button2 }) => {
           </div>
         </div>
 
-        <Image className="absolute top-0 -right-48 xl:w-[550px] xl:-right-7 xl:top-16 lg:static lg:w-full h-auto" />
+        <Image className="absolute top-0 -right-48 w-[700px] xl:w-[550px] xl:-right-7 xl:top-16 lg:static lg:w-full h-auto" />
       </Container>
     </section>
   );

--- a/src/pages/summit-2021.jsx
+++ b/src/pages/summit-2021.jsx
@@ -14,7 +14,7 @@ const hero = {
   date: 'August 18-19th',
   title: 'Summit 2021',
   description:
-    '<p>eBPF Summit, a virtual event, targeted at DevOps, SecOps, platform architects, and developers is open for registration.</p><p>Interested in speaking at eBPF Summit?<br> The <a href="https://sessionize.com/ebpf-summit-2021/" target="_blank" rel="noopener noreferrer">Call For Papers</a> for lightning talks is open until July 23!</p>',
+    '<p>eBPF Summit, a virtual event, targeted at DevOps, SecOps, platform architects, and developers is open for registration.</p>',
   button1: {
     url: 'https://docs.google.com/forms/d/e/1FAIpQLSfZRsMmxxjoQK2Fo0nhyrQt25AEkq0mpTPQfOAAe6h5oVljWQ/viewform?embedded=true',
     title: 'Register',
@@ -27,9 +27,13 @@ const hero = {
 
 const agenda = {
   title: 'Agenda',
-  subtitle: 'Full schedule coming soon!',
-  description:
-    'You can expect sessions running both days at 9am-12 midday Pacific / 12 midday-3pm Eastern / 5pm-8pm UK / 6pm-9pm Europe',
+  subtitle:
+    'Sessions run both days 9am-1pm Pacific / 12 midday-4pm Eastern / 5pm-9pm UK / 6pm-10pm Europe',
+  link: {
+    url: 'https://ebpf-summit-2021.sessionize.com/',
+    title: 'View schedule and speakers',
+  },
+  description: 'More sessions being added - check back soon!',
 };
 
 const information = {


### PR DESCRIPTION
**Describe what changes this pull request brings**
This pull request updates content in the Hero & Agenda sections.
- [x] Remove the two lines of text "Interested in speaking….until July 23!" from the header at the top
In the Agenda section
- [x] Remove "Full schedule coming soon"
- [x] Change the text to "Sessions run both days 9am-1pm Pacific / 12 midday-4pm Eastern / 5pm-9pm UK / 6pm-10pm Europe"
- [x] Have a bold yellow link "View schedule and speakers" linking to https://ebpf-summit-2021.sessionize.com/
- [x] add text "More sessions being added - check back soon!"

**Steps to test**
1. Visit https://deploy-preview-1--ebpf-summit-2021.netlify.app/summit-2021/
2. Check changes mentioned above

**Screenshots**
![image](https://user-images.githubusercontent.com/48465000/127350865-34b5855d-3321-4e60-b3e1-b31ca9713231.png)
![image](https://user-images.githubusercontent.com/48465000/127350988-f3773a48-0d84-4e6b-a0f1-be24492d1453.png)

<!-- 
Attach any relevant screenshots.
If this pull request does not represent any visual changes, set N/A as a value for it.
-->

**Checklist**
<!--
Check all applicable items.
-->

- [x] I've tested everything and everything works well
- [x] I've checked these changes on all breakpoints



