### PR TITLE
feat: directly link to ctf page

### DIFF
--- a/src/components/shared/summit-header/summit-header.jsx
+++ b/src/components/shared/summit-header/summit-header.jsx
@@ -14,7 +14,7 @@ const navigation = [
   { name: 'Featured Speakers', href: '/summit-2021/#featured-speakers' },
   { name: 'Information', href: '/summit-2021/#information' },
   { name: 'Schedule', href: '/summit-2021/#schedule' },
-  { name: 'CTF', href: '/summit-2021/#capture-the-flag' },
+  { name: 'CTF', href: '/summit-2021/ctf' },
   { name: `Last year's summit`, href: `/summit-2021/#last-year's-summit` },
 ];
 


### PR DESCRIPTION
We have now a separate page for the ctf instructions, the header link
should directly link to it.
