### PR TITLE
feat: remove the CFP banner

### DIFF
--- a/src/components/pages/summit-2022/summit-header/summit-header.jsx
+++ b/src/components/pages/summit-2022/summit-header/summit-header.jsx
@@ -15,7 +15,6 @@ import Logo from 'images/logo.inline.svg';
 const HUBSPOT_FORM_ID = 'ecd4bee1-a31f-4c5c-83b6-ee7df83c885d';
 
 const navigation = [
-  { name: 'Call for proposals', href: '/summit-2022/#cfp' },
   { name: 'Information', href: '/summit-2022/#information' },
   { name: 'Agenda', href: '/summit-2022/#agenda' },
   { name: `Last year's summit`, href: `/summit-2022/#last-year-summit` },

--- a/src/pages/summit-2022.jsx
+++ b/src/pages/summit-2022.jsx
@@ -2,7 +2,6 @@
 import React from 'react';
 
 import Banner from 'components/pages/summit-2022/banner';
-import CfpBanner from 'components/pages/summit-2022/cfp-banner';
 import Hero from 'components/pages/summit-2022/hero';
 import Information from 'components/pages/summit-2022/information';
 import LastYear from 'components/pages/summit-2022/last-year';
@@ -73,7 +72,6 @@ const Summit2022 = () => (
       }}
     />
     <Hero {...hero} />
-    <CfpBanner />
     <Information />
     <LastYear {...lastYear} />
     <Banner />


### PR DESCRIPTION
This PR updates [the 2022 Summit page](https://deploy-preview-33--ebpf-summit-2021.netlify.app/summit-2022/) to remove the CFP link and banner