### PR TITLE
feat: add buttons Watch day to hero section

### DIFF
--- a/src/components/pages/summit-2022/hero/hero.jsx
+++ b/src/components/pages/summit-2022/hero/hero.jsx
@@ -1,107 +1,75 @@
 import { StaticImage } from 'gatsby-plugin-image';
 import PropTypes from 'prop-types';
-import React, { useState } from 'react';
+import React from 'react';
 
 import Button from 'components/shared/button';
 import Container from 'components/shared/container';
 import Heading from 'components/shared/heading';
-import RegisterFormModal from 'components/shared/register-form-modal';
-import SlackIcon from 'icons/slack.inline.svg';
 
 import illustration from './images/illustration.svg';
 
-const Hero = ({ date, title, description, firstButton, secondButton }) => {
-  const [isOpen, setIsOpen] = useState(false);
-  const openModal = () => {
-    setIsOpen(true);
-  };
-  const closeModal = (e) => {
-    e.stopPropagation();
-    setIsOpen(false);
-  };
-  return (
-    <section className="relative lg:overflow-hidden">
-      <div className="absolute right-0 md:-right-4 sm:-right-14 -top-20 w-[200px] xl:hidden lg:block">
-        <StaticImage src="./images/drop-1.jpg" alt="" loading="eager" aria-hidden />
-      </div>
-      <div className="absolute -top-3 2xl:-left-14 2xl:top-12 left-0 md:-left-4 sm:-left-14 sm:-top-24 w-[128px] xl:hidden lg:block lg:-top-3 lg:left-0">
-        <StaticImage src="./images/drop-2.jpg" alt="" loading="eager" aria-hidden />
-      </div>
-      <div className="absolute top-96 2xl:top-[450px] 2xl:-left-10 left-0 md:top-64 md:-left-20 sm:hidden w-[330px] 2xl:w-[280px] xl:hidden lg:block lg:top-80 lg:left-0">
-        <StaticImage src="./images/honey.jpg" alt="" loading="eager" aria-hidden />
-      </div>
-      <Container className="pt-28 pb-6 lg:pb-0 md:pt-24 lg:w-[95%]">
-        <div className="max-w-[644px] lg:max-w-full lg:text-center">
-          <time
-            className="bg-white with-orange-highlight inline-block p-2 font-bold text-center leading-none uppercase border-2 rounded-md text-black border-primary-5 border-opacity-30"
-            dangerouslySetInnerHTML={{ __html: date }}
-          />
-
-          <Heading
-            className="mt-7 text-[80px] sm:text-5xl leading-tight font-black"
-            tag="h1"
-            size="3xl"
-            innerHTML={title}
-          />
-          <div
-            className="mt-4 max-w-lg lg:max-w-xl md:max-w-lg sm:max-w-sm lg:mx-auto space-y-4 text-xl with-link-primary md:text-lg md:space-y-4 font-semibold"
-            dangerouslySetInnerHTML={{ __html: description }}
-          />
-          <div className="flex space-x-6 sm:flex-col mt-9 sm:space-x-0 sm:space-y-3 xs:w-full lg:justify-center">
-            <Button
-              className="xs:px-3.5 xs:flex-1 rounded-lg sm:min-h-[44px]"
-              type="button"
-              theme="orange"
-              size="sm"
-              onClick={openModal}
-            >
-              {firstButton.title}
-            </Button>
-            <div className="flex space-x-6 sm:w-full sm:space-x-3">
-              <Button
-                className="xs:px-3.5 sm:flex-1 flex items-center space-x-3 rounded-lg"
-                to={secondButton.url}
-                theme="gray"
-                size="sm"
-              >
-                <SlackIcon className="shrink-0 w-6 h-6 sm:w-5 sm:h-5" />
-                <span>{secondButton.title}</span>
-              </Button>
-            </div>
-          </div>
-        </div>
-        <img
-          src={illustration}
-          className="absolute top-[4.5rem] xl:top-24 right-8 w-[648px] xl:w-[490px] xl:right-0 lg:static lg:w-full h-auto lg:mt-12"
-          alt="Illustration"
+const Hero = ({ date, title, description, ctaButtons }) => (
+  <section className="relative lg:overflow-hidden">
+    <div className="absolute right-0 md:-right-4 sm:-right-14 -top-20 w-[200px] xl:hidden lg:block">
+      <StaticImage src="./images/drop-1.jpg" alt="" loading="eager" aria-hidden />
+    </div>
+    <div className="absolute -top-3 2xl:-left-14 2xl:top-12 left-0 md:-left-4 sm:-left-14 sm:-top-24 w-[128px] xl:hidden lg:block lg:-top-3 lg:left-0">
+      <StaticImage src="./images/drop-2.jpg" alt="" loading="eager" aria-hidden />
+    </div>
+    <div className="absolute top-96 2xl:top-[450px] 2xl:-left-10 left-0 md:top-64 md:-left-20 sm:hidden w-[330px] 2xl:w-[280px] xl:hidden lg:block lg:top-80 lg:left-0">
+      <StaticImage src="./images/honey.jpg" alt="" loading="eager" aria-hidden />
+    </div>
+    <Container className="pt-28 pb-6 lg:pb-0 md:pt-24 lg:w-[95%]">
+      <div className="max-w-[644px] lg:max-w-full lg:text-center">
+        <time
+          className="bg-white with-orange-highlight inline-block p-2 font-bold text-center leading-none uppercase border-2 rounded-md text-black border-primary-5 border-opacity-30"
+          dangerouslySetInnerHTML={{ __html: date }}
         />
-      </Container>
-      <RegisterFormModal isOpen={isOpen} closeModal={closeModal} />
-    </section>
-  );
-};
+
+        <Heading
+          className="mt-7 text-[80px] sm:text-5xl leading-tight font-black"
+          tag="h1"
+          size="3xl"
+          innerHTML={title}
+        />
+        <div
+          className="mt-4 max-w-lg lg:max-w-xl md:max-w-lg sm:max-w-sm lg:mx-auto space-y-4 text-xl with-link-primary md:text-lg md:space-y-4 font-semibold"
+          dangerouslySetInnerHTML={{ __html: description }}
+        />
+        <div className="flex space-x-5 sm:flex-col mt-9 sm:space-x-0 sm:space-y-3 xs:w-full lg:justify-center">
+          {ctaButtons.map(({ title, url, theme }, index) => (
+            <Button
+              className="xs:px-3.5 sm:flex-1 flex items-center space-x-3 px-5 rounded-lg"
+              size="sm"
+              to={url}
+              theme={theme}
+              key={index}
+            >
+              {title}
+            </Button>
+          ))}
+        </div>
+      </div>
+      <img
+        src={illustration}
+        className="absolute top-[4.5rem] xl:top-24 right-8 w-[648px] xl:w-[490px] xl:right-0 lg:static lg:w-full h-auto lg:mt-12"
+        alt="Illustration"
+      />
+    </Container>
+  </section>
+);
 
 Hero.propTypes = {
   date: PropTypes.string.isRequired,
   title: PropTypes.string.isRequired,
   description: PropTypes.string.isRequired,
-  firstButton: PropTypes.shape({
-    url: PropTypes.string,
-    title: PropTypes.string.isRequired,
-  }),
-  secondButton: PropTypes.shape({
-    url: PropTypes.string,
-    title: PropTypes.string.isRequired,
-  }),
-};
-
-Hero.defaultProps = {
-  firstButton: {
-    url: null,
-  },
-  secondButton: {
-    url: null,
-  },
+  ctaButtons: PropTypes.arrayOf(
+    PropTypes.shape({
+      title: PropTypes.string.isRequired,
+      url: PropTypes.string.isRequired,
+      theme: PropTypes.string.isRequired,
+    })
+  ).isRequired,
 };
 
 export default Hero;

--- a/src/pages/summit-2022.jsx
+++ b/src/pages/summit-2022.jsx
@@ -18,13 +18,23 @@ const hero = {
   title: 'eBPF Summit',
   description:
     '<p>eBPF Summit is a virtual event, targeted at DevOps, SecOps, platform architects, security engineers, and developers. Register to save the date and stay updated on event information.</p>',
-  firstButton: {
-    title: 'Register for event',
-  },
-  secondButton: {
-    url: 'https://ebpf.io/slack',
-    title: 'Join Summit Slack',
-  },
+  ctaButtons: [
+    {
+      url: 'https://ebpf.io/slack',
+      title: 'Join Summit Slack',
+      theme: 'orange',
+    },
+    {
+      url: 'https://ebpf.io/summit-2022/day-1',
+      title: 'Watch day 1',
+      theme: 'gray',
+    },
+    {
+      url: 'https://ebpf.io/summit-2022/day-2',
+      title: 'Watch day 2',
+      theme: 'gray',
+    },
+  ],
 };
 
 const speakerWall = {


### PR DESCRIPTION
**Describe what changes this pull request brings**
This pull request brings the CTA buttons Watch day & Watch day 2 to the Hero section on Summit 2022 page.
<!--
Some examples:
1. This pull request brings component Hero for the page Home.
2. This pull request adds fixes for the responsive version of the page Blog.
3. This pull request fixes user assignment via phone number in the existing stay.
-->

**Screenshots**
<img width="1243" alt="image" src="https://user-images.githubusercontent.com/48465000/192764907-2a6b1d2b-1588-4e6c-9238-0ef510cf9c59.png">

<!-- 
Attach any relevant screenshots.
If this pull request does not represent any visual changes, set N/A as a value for it.
-->

**References**
<!--
Tag any related issues or tasks in Notion.
Some examples:
1. Resolves #1.
2. Closes #1.
3. Fixes #1.
4. Closes the task [Update README](https://www.notion.so/) in Notion.
You can read more about linking a pull request to an issue here — https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
If this pull request does not contain any references, set N/A as a value for it.
-->
